### PR TITLE
Use GitHub Actions for Unix Builds

### DIFF
--- a/.github/workflows/cmake-linux64.yml
+++ b/.github/workflows/cmake-linux64.yml
@@ -1,0 +1,35 @@
+name: CMake-Linux64
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Dependancies
+      run: |
+        sudo apt update
+        sudo apt install gcc
+        sudo apt install libogg-dev
+        sudo apt install libsdl2-dev
+        sudo apt install zlib1g-dev
+        sudo apt install libvorbis-dev
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake ../src
+        make
+    - uses: actions/upload-artifact@v3
+      with:
+        name: hypseus
+        path: hypseus

--- a/.github/workflows/cmake-linux64.yml
+++ b/.github/workflows/cmake-linux64.yml
@@ -19,6 +19,8 @@ jobs:
       run: |
         sudo apt update
         sudo apt install gcc
+        sudo apt install glibc
+        sudo apt install glibc-tools
         sudo apt install libogg-dev
         sudo apt install libsdl2-dev
         sudo apt install libsdl2-ttf-dev

--- a/.github/workflows/cmake-linux64.yml
+++ b/.github/workflows/cmake-linux64.yml
@@ -19,8 +19,10 @@ jobs:
       run: |
         sudo apt update
         sudo apt install gcc
-        sudo apt install glibc
+        sudo apt install glibc-source
         sudo apt install glibc-tools
+        sudo apt install libc6
+        sudo apt install libc-dev-bin
         sudo apt install libogg-dev
         sudo apt install libsdl2-dev
         sudo apt install libsdl2-ttf-dev

--- a/.github/workflows/cmake-linux64.yml
+++ b/.github/workflows/cmake-linux64.yml
@@ -34,4 +34,4 @@ jobs:
     - uses: actions/upload-artifact@v3
       with:
         name: hypseus
-        path: hypseus
+        path: build/hypseus

--- a/.github/workflows/cmake-linux64.yml
+++ b/.github/workflows/cmake-linux64.yml
@@ -21,6 +21,8 @@ jobs:
         sudo apt install gcc
         sudo apt install libogg-dev
         sudo apt install libsdl2-dev
+        sudo apt install libsdl2-ttf-dev
+        sudo apt install libsdl2-image-dev
         sudo apt install zlib1g-dev
         sudo apt install libvorbis-dev
     - name: Build

--- a/.github/workflows/cmake-macos64.yml
+++ b/.github/workflows/cmake-macos64.yml
@@ -20,6 +20,7 @@ jobs:
         brew update
         brew install autoconf
         brew install automake
+        brew install glibc
         brew install pkg-config
         brew install sdl2
         brew install sdl2_ttf

--- a/.github/workflows/cmake-macos64.yml
+++ b/.github/workflows/cmake-macos64.yml
@@ -1,0 +1,39 @@
+name: CMake-MacOS64
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+env:
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Install Dependancies
+      run: |
+        brew update
+        brew install autoconf
+        brew install automake
+        brew install pkg-config
+        brew install sdl2
+        brew install sdl2_ttf
+        brew install sdl2_image
+        brew install libtool
+        brew install libvorbis
+        brew install libogg
+    - name: Build
+      run: |
+        mkdir build
+        cd build
+        cmake ../src
+        make
+    - uses: actions/upload-artifact@v3
+      with:
+        name: hypseus
+        path: build/hypseus


### PR DESCRIPTION
Tried my hand at generating some CI scripts for MacOS64 and Linux64 (Ubuntu) builds. Ubuntu is working fine, but macos is giving an error on `ld -lsdl2` for some reason despite specifically installing it with homebrew.

Didn't include Windows build as no instructions were provided for building explicitly.